### PR TITLE
Changed 'is WooCommerce enabled' check to a version that also works on multisite installations

### DIFF
--- a/montapacking-checkout.php
+++ b/montapacking-checkout.php
@@ -61,7 +61,7 @@ add_filter("plugin_action_links_$plugin", 'montacheckout_plugin_add_settings_lin
 
 
 ## Check of we in woocommerce zijn
-if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
+if (is_plugin_active('woocommerce/woocommerce.php')) {
 
     ## Standaard woocommerce verzending uitschakelen
     add_filter('woocommerce_shipping_calculator_enable_postcode', false);


### PR DESCRIPTION
The current version of the plugin does not work on multisite installations, and enters the [else](https://github.com/MontaServices/woocommerce-monta-checkout/blob/68a55c1f161e25e4fca2f8804d8bcb73f874e69c/montapacking-checkout.php#L114) statement.

This change uses the [is_plugin_active](https://developer.wordpress.org/reference/functions/is_plugin_active/) function, which does work correctly on multisite installations. A good summary can be found [here](https://rudrastyh.com/wordpress/check-if-plugin-is-active-in-multisite.html#is_plugin_active).