### PR TITLE
fix: Replace get_virtual() with is_virtual() and add variation support

### DIFF
--- a/src/Packing.php
+++ b/src/Packing.php
@@ -30,9 +30,13 @@ class Packing
 
         // Controleer elk product in de winkelwagen
         foreach ($cart_items as $cart_item) {
-            $product = wc_get_product($cart_item['product_id']);
+            if ($cart_item['variation_id']) {
+                $product = wc_get_product($cart_item['variation_id']);
+            } else {
+                $product = wc_get_product($cart_item['product_id']);
+            }
 
-            if ($product && $product->get_virtual()) {
+            if ($product && $product->is_virtual()) {
                 $has_virtual_products = true;
             }
         }
@@ -126,7 +130,7 @@ class Packing
                     $product = wc_get_product($cart_item['product_id']);
                 }
 
-                $virtual = $product->get_virtual();
+                $virtual = $product->is_virtual();
 
                 if ($virtual) {
                     $hasDigitalProducts = true;
@@ -464,7 +468,7 @@ class Packing
         $hasDigitalProducts = false;
         $hasPhysicalProducts = false;
         foreach ($items as $values) {
-            $virtual = $values['data']->get_virtual();
+            $virtual = $values['data']->is_virtual();
 
             if ($virtual) {
                 $hasDigitalProducts = true;
@@ -866,7 +870,7 @@ class Packing
                     $x++;
                 }
 
-                $virtual = $product->get_virtual();
+                $virtual = $product->is_virtual();
 
                 if ($virtual) {
                     $hasDigitalProducts = true;


### PR DESCRIPTION
- Replace all instances of get_virtual() with is_virtual() for proper WooCommerce virtual product detection
- Add variation handling in checkout_validate() method to detect virtual product variations
- Ensure consistent virtual product detection across all methods (checkout_validate, checkout_store, get_shipping_total, get_frames)
- Fixes issues with custom virtual products not being detected properly

This resolves compatibility issues with WooCommerce's standard virtual product functionality and ensures proper handling of virtual product variations throughout the checkout process.